### PR TITLE
Convert specs to RSpec 3.7.1 syntax with Transpec

### DIFF
--- a/spec/warden/ldap/configuration_spec.rb
+++ b/spec/warden/ldap/configuration_spec.rb
@@ -3,7 +3,7 @@ describe Warden::Ldap::Configuration do
     it 'returns Rails.env if defined' do
       rails = double(:env => :rails_environemnt)
       stub_const("Rails", rails)
-      described_class.new.env.should == :rails_environemnt
+      expect(described_class.new.env).to eq(:rails_environemnt)
     end
 
     it 'raises error if no environemnt defined' do

--- a/spec/warden/ldap/strategy_spec.rb
+++ b/spec/warden/ldap/strategy_spec.rb
@@ -22,7 +22,7 @@ describe Warden::Ldap::Strategy do
   describe '#authenticte!' do
     before :each do
       @env = env_with_params("/", {'username' => 'test', 'password' => 'secret'})
-      subject.stub(:valid? => true)
+      allow(subject).to receive_messages(:valid? => true)
     end
 
     let(:test_connection) { double(Warden::Ldap::Connection) }
@@ -37,21 +37,21 @@ describe Warden::Ldap::Strategy do
         .and_return('Samuel@swiftpenguin.com')
 
       allow(Warden::Ldap::Connection).to receive(:new).and_return(test_connection)
-      subject.should_receive(:success!)
+      expect(subject).to receive(:success!)
       subject.authenticate!
     end
 
     it 'fails if ldap connection fails' do
       allow(test_connection).to receive(:authenticate!).and_return(false)
       allow(Warden::Ldap::Connection).to receive(:new).and_return(test_connection)
-      subject.should_receive(:fail!)
+      expect(subject).to receive(:fail!)
       subject.authenticate!
     end
 
     it 'fails if Net::LDAP::LdapError was raised' do
       allow(test_connection).to receive(:authenticate!).and_raise(Net::LDAP::LdapError)
       allow(Warden::Ldap::Connection).to receive(:new).and_return(test_connection)
-      subject.should_receive(:fail!)
+      expect(subject).to receive(:fail!)
       subject.authenticate!
     end
 

--- a/spec/warden/ldap_spec.rb
+++ b/spec/warden/ldap_spec.rb
@@ -23,10 +23,10 @@ describe Warden::Ldap do
       env['warden'].authenticate(:ldap)
       success_app.call(env)
     end
-    Warden::Ldap::Connection.any_instance.stub(:authenticate! => true)
-    Warden::Ldap::Connection.any_instance.stub(:ldap_param_value).with('samAccountName').and_return('samuel')
-    Warden::Ldap::Connection.any_instance.stub(:ldap_param_value).with('cn').and_return('Samuel')
-    Warden::Ldap::Connection.any_instance.stub(:ldap_param_value).with('mail').and_return('Samuel@swiftpenguin.com')
+    allow_any_instance_of(Warden::Ldap::Connection).to receive_messages(:authenticate! => true)
+    allow_any_instance_of(Warden::Ldap::Connection).to receive(:ldap_param_value).with('samAccountName').and_return('samuel')
+    allow_any_instance_of(Warden::Ldap::Connection).to receive(:ldap_param_value).with('cn').and_return('Samuel')
+    allow_any_instance_of(Warden::Ldap::Connection).to receive(:ldap_param_value).with('mail').and_return('Samuel@swiftpenguin.com')
     result = setup_rack(app).call(env)
     expect(result.first).to eq 200
     expect(result.last).to eq ['You Rock!']
@@ -38,10 +38,10 @@ describe Warden::Ldap do
       env['warden'].authenticate(:ldap)
       success_app.call(env)
     end
-    Warden::Ldap::Connection.any_instance.stub(:authenticate! => true)
-    Warden::Ldap::Connection.any_instance.stub(:ldap_param_value).with('samAccountName').and_return('bobby')
-    Warden::Ldap::Connection.any_instance.stub(:ldap_param_value).with('cn').and_return('Samuel')
-    Warden::Ldap::Connection.any_instance.stub(:ldap_param_value).with('mail').and_return('Samuel@swiftpenguin.com')
+    allow_any_instance_of(Warden::Ldap::Connection).to receive_messages(:authenticate! => true)
+    allow_any_instance_of(Warden::Ldap::Connection).to receive(:ldap_param_value).with('samAccountName').and_return('bobby')
+    allow_any_instance_of(Warden::Ldap::Connection).to receive(:ldap_param_value).with('cn').and_return('Samuel')
+    allow_any_instance_of(Warden::Ldap::Connection).to receive(:ldap_param_value).with('mail').and_return('Samuel@swiftpenguin.com')
     result = setup_rack(app).call(env)
     expect(env['warden'].user.username).to eq 'bobby'
     expect(env['warden'].user.name).to eq 'Samuel'


### PR DESCRIPTION
This conversion is done by Transpec 3.3.0 with the following command:
    transpec

* 6 conversions
    from: Klass.any_instance.stub(:message)
      to: allow_any_instance_of(Klass).to receive(:message)

* 3 conversions
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)

* 2 conversions
    from: Klass.any_instance.stub(:message => value)
      to: allow_any_instance_of(Klass).to receive_messages(:message => value)

* 1 conversion
    from: == expected
      to: eq(expected)

* 1 conversion
    from: obj.should
      to: expect(obj).to

* 1 conversion
    from: obj.stub(:message => value)
      to: allow(obj).to receive_messages(:message => value)

For more details: https://github.com/yujinakayama/transpec#supported-conversions