### PR TITLE
Gemspec: fix typo, don't mention directories which don't exist

### DIFF
--- a/warden-ldap.gemspec
+++ b/warden-ldap.gemspec
@@ -9,14 +9,13 @@ Gem::Specification.new do |spec|
   spec.version       = Warden::Ldap::VERSION
   spec.authors       = ['Maher Hawash']
   spec.email         = ['gmhawash@gmail.com']
-  spec.description   = 'Provides ldap strategy for warden'
-  spec.summary       = 'Provides ldap strategy for wrden'
+  spec.description   = 'Provides ldap strategy for Warden'
+  spec.summary       = 'Provides ldap strategy for Warden'
   spec.homepage      = ''
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.test_files    = spec.files.grep(%r{^(spec)/})
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.3'


### PR DESCRIPTION
This changes the gemspec to only refer to directories which exist in this repo.