### PR TITLE
 Introduce skip_srv_record_resolution YAML configuration to fall back to using an A record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+spec/examples.txt

--- a/README.md
+++ b/README.md
@@ -77,11 +77,13 @@ authorizations: &AUTHORIZATIONS
 
 test: 
   <<: *AUTHORIZATIONS
-  host: your.ldap.example.com
+  host: localhost
   port: <%= ENV['MY_SPECIAL_TEST_URI_PORT'] %>
+  skip_srv_record_resolution: true
 development: 
   <<: *AUTHORIZATIONS
-  host: your.ldap.example.com
+  host: localhost
+  skip_srv_record_resolution: true
 production: 
   <<: *AUTHORIZATIONS
   host: your.ldap.example.com

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ And then execute:
 ## Usage
 
 1. Install gem per instructions above
-2. Initialize the `Warden::Ldap` adapter:
+2. Initialize the `Warden::Ldap` adapter - this also registers the `:ldap` Warden Strategy
 
 ```ruby
 Warden::Ldap.configure do |c|
@@ -30,7 +30,7 @@ Warden::Ldap.configure do |c|
 end
 ```
 
-3. Add the `ldap_config.yml` to configure connection to ldap server. See `spec/fixtures/ldap_config_sample.yml`.
+3. Add the `ldap_config.yml` to configure a connection to LDAP server. See `spec/fixtures/ldap_config_sample.yml`.
 
 ## Configuration
 

--- a/spec/fixtures/ldap_config_sample.yml
+++ b/spec/fixtures/ldap_config_sample.yml
@@ -1,7 +1,7 @@
 ## Authorizations
-# Uncomment out the merging for each enviornment that you'd like to include.
+# Uncomment out the merging for each environment that you'd like to include.
 # You can also just copy and paste the tree (do not include the "authorizations") to each
-# enviornment if you need something different per enviornment.
+# environment if you need something different per environment.
 authorizations: &AUTHORIZATIONS
   group_base: ou=groups,dc=test,dc=com
   ## Requires config.ldap_check_group_membership in devise.rb be true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,4 +28,5 @@ RSpec.configure do |config|
   config.order = 'random'
 
   config.disable_monkey_patching!
+  config.example_status_persistence_file_path = 'spec/examples.txt'
 end

--- a/spec/warden/ldap_spec.rb
+++ b/spec/warden/ldap_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Warden::Ldap do
     allow_any_instance_of(Warden::Ldap::Connection).to receive(:ldap_param_value).with('samAccountName').and_return('bobby')
     allow_any_instance_of(Warden::Ldap::Connection).to receive(:ldap_param_value).with('cn').and_return('Samuel')
     allow_any_instance_of(Warden::Ldap::Connection).to receive(:ldap_param_value).with('mail').and_return('Samuel@swiftpenguin.com')
-    result = setup_rack(app).call(env)
+    _result = setup_rack(app).call(env)
     expect(env['warden'].user.username).to eq 'bobby'
     expect(env['warden'].user.name).to eq 'Samuel'
   end


### PR DESCRIPTION
This PR fixes #11.

- a new setting `skip_srv_record_resolution ` in YAML
- skip looking up SRV records if that setting is truthy. Instead, use `host` as the only host available