### PR TITLE
[Security] Avoid using net-ldap before 0.16.0

### DIFF
--- a/warden-ldap.gemspec
+++ b/warden-ldap.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
-  spec.add_runtime_dependency 'net-ldap', '~> 0.3'
+  spec.add_runtime_dependency 'net-ldap', '>= 0.16.0'
   spec.add_runtime_dependency 'psych', '>= 3.0.0'
   spec.add_runtime_dependency 'warden', '~> 1.2.1'
 end


### PR DESCRIPTION
This avoids a security warning from GitHub. Thanks, GitHub.